### PR TITLE
footer, descriptions, formatting

### DIFF
--- a/Current Solutions/AprilTag.md
+++ b/Current Solutions/AprilTag.md
@@ -1,6 +1,7 @@
 ---
 title: AprilTag
 parent: Current Solutions
+description: Overall price: varies wildly | AprilTag trackers consists of printed or even hand-drawn "QR-code style" markers that get tracked in 6DOF space by a webcam.
 ---
 
 # AprilTag

--- a/Current Solutions/AprilTag.md
+++ b/Current Solutions/AprilTag.md
@@ -5,10 +5,13 @@ description: Overall price: varies wildly | AprilTag trackers consists of printe
 ---
 
 # AprilTag
+This works by having a webcam track the shape of printed or hand-drawn "QR-code style" markers on your ankles and waist. Position and rotation is inferred from this.
 
-Overall cost: Varies wildly. They recommend trying what you already have on hand before trying to go out and purchase a specific webcam for it. Only other cost is the printing out and DIY of the trackers themselves.
+The developer recommends trying what you already have on hand before trying to go out and purchase a specific webcam for it. Only other cost is the printing out and DIY of the trackers themselves.
 
-Requirements:
+**Overall price:** varies wildly
+
+### Requirements:
 * For detailed requirements, refer to here. The proper method requires much more setup than I could detail here. https://github.com/ju1ce/April-Tag-VR-FullBody-Tracker/wiki/Requirements
 * Camera meeting the following specifications(as pulled from their wiki):
   * Resolution: A resolution of 720p is usually optimal. 480p can work, but you will have reduced range of detection.
@@ -24,6 +27,6 @@ Requirements:
 
 For Support: https://discord.gg/g2ctkXB4bb
 
-Thoughts:
+### Thoughts:
 * If you can get everything set up optimally, the tracking quality is impressive. See an example here: https://www.youtube.com/watch?v=Bngdi5zPxXc
 * There is also MediaPipe which only requires a Webcam and a piece of software, but the requirements are different and it is a work-in-progress. Not recommended. Read up on it here: https://github.com/ju1ce/Mediapipe-VR-Fullbody-Tracking

--- a/Current Solutions/BSVTOVR.md
+++ b/Current Solutions/BSVTOVR.md
@@ -3,6 +3,7 @@ title: Base Stations + Vive Trackers
 parent: Current Solutions
 description: Overall price: $700-$900 | Vive Trackers are often considered the standard for body tracking, while expensive, they provide the best tracking quality.
 ---
+
 # Base Stations + Vive Trackers
 Despite the fact HTC makes the trackers, **you can use them with any headset** given you add [compatible](#remarks) base stations to your setup. It's often considered the de facto standard for full-body tracking.
 

--- a/Current Solutions/BSVTOVR.md
+++ b/Current Solutions/BSVTOVR.md
@@ -1,6 +1,7 @@
 ---
 title: Base Stations + Vive Trackers
 parent: Current Solutions
+description: Overall price: $700-$900 | Vive Trackers are often considered the standard for body tracking, while expensive, they provide the best tracking quality.
 ---
 # Base Stations + Vive Trackers
 Despite the fact HTC makes the trackers, **you can use them with any headset** given you add [compatible](#remarks) base stations to your setup. It's often considered the de facto standard for full-body tracking.

--- a/Current Solutions/K2EX_Amethyst.md
+++ b/Current Solutions/K2EX_Amethyst.md
@@ -1,6 +1,7 @@
 ---
 title: K2EX / Amethyst
 parent: Current Solutions
+description: Overall price: $20-$40+ | Kinect, despite its limitations can do much more than most users think on a very tight budget.
 ---
 # K2EX / Amethyst
 

--- a/Current Solutions/K2EX_Amethyst.md
+++ b/Current Solutions/K2EX_Amethyst.md
@@ -3,11 +3,13 @@ title: K2EX / Amethyst
 parent: Current Solutions
 description: Overall price: $20-$40+ | Kinect, despite its limitations can do much more than most users think on a very tight budget.
 ---
+
 # K2EX / Amethyst
+Kinect is regarded as "not real full-body" by many. Despite this, developers have continued to work to improve the tracking and the experience over the years.
 
-Overall Price: $20-$40+
+**Overall Price:** $20-$40+
 
-Requirements:
+### Requirements:
 * Xbox 360 or Xbox One Kinect with power/USB adapter to plug into wall and computer
   * Warning: Xbox One Kinect is NOT recommended. While newer, it is known to be incredibly problematic. Refer to here: https://docs.k2vr.tech/en/one/common-issues/
   * Note: If purchasing adapter separately, avoid purchasing from Amazon. Those adapters are known to have trouble.
@@ -19,12 +21,12 @@ Requirements:
   * Amethyst: https://github.com/KinectToVR
   * The difference between the two is that Amethyst is as-of-yet not fully released software. However, it is the one recommended to get set up with since it is the focus nowadays.
 
-* Note from Project Lead:
-"As of writing, K2EX and Amethyst have similar tracking quality (This is going to change drastically in the future). While still in active development and only out in a technical preview, Amethyst is often recommended by the developers because of it's hundreds of bugfixes over the older K2EX app. They just want you to be in their Discord listed below if you run into problems during the preview phase."
+### Note from Project Lead:
+> As of writing, K2EX and Amethyst have similar tracking quality (This is going to change drastically in the future). While still in active development and only out in a technical preview, Amethyst is often recommended by the developers because of it's hundreds of bugfixes over the older K2EX app. They just want you to be in their Discord listed below if you run into problems during the preview phase. - Noelle, K2VR Team
 
 For Support: https://discord.gg/YBQCRDG
 
-Thoughts:
+### Thoughts:
 * The team of KinectToVR have really brought out the hidden potential of the Kinect hardware. While the Kinect is not perfect and nor is the method, this team has improved upon the software dramatically, and have proven that competent Full-Body Tracking can be done on the cheap, and is worth a shot.
 * As the team states clearly concerning who this is for: “If you want perfect tracking and wanna breakdance and backflip like none other, Kinect isn't for you. But if you want to sit down, do jumping jacks, walk about your huge playspace or anything of the sort, Kinect is wonderful.”
 * There is another software called Driver4VR that has Kinect support, but is not recommended. It can be found on Steam for $17.99.

--- a/Current Solutions/SlimeVR.md
+++ b/Current Solutions/SlimeVR.md
@@ -6,9 +6,9 @@ description: Overall price: $165-$455 | SlimeVR uses fancy kinematics math to fi
 
 # SlimeVR
 
-Overall Price: $165-$455
+**Overall Price:** $165-$455
 
-Requirements:
+### Requirements:
 * For pre-made trackers, you can pre-order on Crowd Supply: https://www.crowdsupply.com/slimevr/slimevr-full-body-tracker
   * Price: $165-$455 depending on the extent of the tracking you are wanting to get, read up on the options at the link above.
 * For DIY trackers, refer to here: https://deiteris.github.io/SlimeVR-Docs-Site/
@@ -19,6 +19,6 @@ Setup Instructions: https://docs.slimevr.dev/server-setup/slimevr-setup.html
 
 Support: https://discord.gg/SlimeVR
 
-Thoughts:
+### Thoughts:
 * SlimeVR is a staple of the DIY side of FBT, and has been used by many people with varying experiences. If you are comfortable with DIY or wish to support their efforts to get some pre-made, you are in good company.
 * There is also owoTrack for the purposes of simple waist tracking, possibly beyond that, which is referred to in the above SlimeVR-Server github link.

--- a/Current Solutions/SlimeVR.md
+++ b/Current Solutions/SlimeVR.md
@@ -1,6 +1,7 @@
 ---
 title: SlimeVR
 parent: Current Solutions
+description: Overall price: $165-$455 | SlimeVR uses fancy kinematics math to figure out body tracker positions from rotation only. This means it can work in small rooms and under blankets.
 ---
 
 # SlimeVR

--- a/Upcoming Solutions/Surplex.md
+++ b/Upcoming Solutions/Surplex.md
@@ -3,11 +3,13 @@ title: Surplex
 parent: Upcoming Solutions
 description: Overall price: $169-$339 | Surplex is an upcoming full-body method that uses shoe-like trackers, only two modules are needed for tracking.
 ---
-#Surplex
 
-Overall price: $169-$339
+# Surplex
+An upcoming full-body method currently on Kickstarter, it uses two shoe-like trackers to track your feet from just rotation alone.
 
-Requirements:
+**Overall price:** $169-$339
+
+### Requirements:
 * The Surplex Basic or Pro model
   * Surplex Basic: $169-$199 Kickstarter, $266 retail
   * Surplex Pro: $199-$239 Kickstarter, $339 retail
@@ -16,6 +18,6 @@ Requirements:
 
 Support: https://discord.gg/N7CjBQVjfp
 
-Thoughts:
+### Thoughts:
 * While early demos were not very good at demonstrating what the team seeks to accomplish, more recent demos have shown a lot of improvement and a good proof of concept.
 * As of this writing, hip tracking latency is still an issue, though this can be mitigated with a dedicated hip tracker if desired according to the team.

--- a/Upcoming Solutions/Surplex.md
+++ b/Upcoming Solutions/Surplex.md
@@ -1,6 +1,7 @@
 ---
 title: Surplex
 parent: Upcoming Solutions
+description: Overall price: $169-$339 | Surplex is an upcoming full-body method that uses shoe-like trackers, only two modules are needed for tracking.
 ---
 #Surplex
 

--- a/_config.yml
+++ b/_config.yml
@@ -1,3 +1,12 @@
 remote_theme: just-the-docs/just-the-docs
 color_scheme: dark
 logo: "assets/2tW17BK.png"
+
+footer_content: ""
+
+# Footer "Edit this page on GitHub" link text
+gh_edit_link: true # show or hide edit this page link
+gh_edit_link_text: "Edit this page on GitHub."
+gh_edit_repository: "https://github.com/starlitpath/starlitpath.github.io" # the github URL for your repo
+gh_edit_branch: "main" # the branch that your docs is served from
+gh_edit_view_mode: "tree" # "tree" or "edit" if you want the user to jump into the editor immediately


### PR DESCRIPTION
- og:description (*description:*) is formatted as `Overall price: 💸💸 |  Short description`
- Turned all sections into level 3 headers.
- Fixed capitalization
- Added in-page longer descriptions about each tracking method.  
  If you're unhappy with these, I can update them.
- Footer should now say "Edit this page on GitHub" with a link to the specific page's source, instead of the default Just The Docs footer.